### PR TITLE
rosdep: add libftdi1-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1807,6 +1807,12 @@ libftdi-dev:
   fedora: [libftdi-devel]
   gentoo: [dev-embedded/libftdi]
   ubuntu: [libftdi-dev]
+libftdi1-dev:
+  arch: [libftdi]
+  debian: [libftdi1-dev]
+  fedora: [libftdi-devel]
+  gentoo: [dev-embedded/libftdi]
+  ubuntu: [libftdi1-dev]
 libftdipp-dev:
   debian:
     buster: [libftdipp1-dev]


### PR DESCRIPTION
libftdi-dev already exists however on ubuntu and debian this installs the
0.* versions that don't have many of the useful eeprom interfaces. The
1.* versions do have these features and are avialable on all of these
distros. For ubuntu and debian the version 1.* versions are provided as
libftdi1-dev. On the other distros the 1.* versions are provided by
default so in those cases libftdi-dev and libftdi1-dev will install the
same package.

Package links:
https://packages.ubuntu.com/xenial/libftdi1-dev
https://packages.debian.org/buster/libftdi1-dev
https://apps.fedoraproject.org/packages/libftdi-devel
https://packages.gentoo.org/packages/dev-embedded/libftdi
https://www.archlinux.org/packages/community/x86_64/libftdi/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/rosdistro/1)
<!-- Reviewable:end -->
