### PR TITLE
Add salt packages to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4545,6 +4545,14 @@ rtmidi:
   debian: [librtmidi-dev]
   fedora: [rtmidi-devel]
   ubuntu: [librtmidi-dev]
+salt-minion:
+  debian: [salt-minion]
+  fedora: [salt-minion]
+  ubuntu: [salt-minion]
+salt-master:
+  debian: [salt-master]
+  fedora: [salt-master]
+  ubuntu: [salt-master]
 sbcl:
   alpine: [sbcl]
   arch: [sbcl]


### PR DESCRIPTION
Add salt packages to rosdep

  Although this is included in the snap via snapcraft, packages need the
  ability to include it in package.xml so that the saltstack packages
  are available during unit testing in Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/rosdistro/2)
<!-- Reviewable:end -->
