### PR TITLE
rosdep: add libcgroup-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1557,6 +1557,12 @@ libceres-dev:
   fedora: [ceres-solver-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   ubuntu: [libceres-dev]
+libcgroup-dev:
+  debian: [libcgroup-dev]
+  fedora: [libcgroup-devel]
+  gentoo: [dev-libs/libcgroup]
+  openembedded: [libcgroup@openembedded-core]
+  ubuntu: [libcgroup-dev]
 libcoin60-dev:
   arch: [coin]
   debian:


### PR DESCRIPTION
libcgroup-dev is useful to controlling cgroups. Specifically it can be
useful for managing memory usage and oom behavior for systemd services.

Package links:
https://packages.ubuntu.com/xenial/libcgroup-dev
https://packages.debian.org/buster/libcgroup-dev
https://packages.gentoo.org/packages/dev-libs/libcgroup
https://www.archlinux.org/packages/community/x86_64/libcgroup/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/rosdistro/3)
<!-- Reviewable:end -->
